### PR TITLE
Add cloud-agent environment caveats and validated startup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+## Cursor Cloud specific instructions
+
+- 이 저장소의 핵심 서비스는 Streamlit 앱(`streamlit/main.py`)이며, 상대 경로(`LoLesports_data/`, `output/`, `streamlit/fonts/`)를 사용하므로 항상 저장소 루트(`/workspace`)에서 실행한다.
+- CSV/PKL 모델 아티팩트는 Git LFS로 추적된다(`.gitattributes` 참고). 브랜치 전환/새 세션 시작 후 앱 실행 전 `git lfs pull`과 `git lfs checkout`이 필요하다.
+- 앱 실행 기본 명령은 `.devcontainer/devcontainer.json`의 `postAttachCommand`를 기준으로 한다(`streamlit run streamlit/main.py ...`).
+- 헬로월드 검증은 `경기 전 사전예측` 페이지에서 기본값으로 `예측` 버튼을 눌러 승리 확률 2줄이 출력되는지 확인하는 플로우를 사용한다.
+- `LCK 팀 지표 확인` 페이지는 GitHub Raw CSV를 직접 읽으므로 네트워크 제한이 있으면 해당 페이지 데이터 렌더링이 실패할 수 있다.
+- 이 저장소에는 전용 lint/test 설정 파일이 없다. 빠른 검증은 `python -m py_compile streamlit/main.py streamlit/pg/*.py`(구문 점검)와 `python -m unittest discover -v`(테스트 스위트 존재 여부 점검)로 수행한다.

--- a/streamlit/lck_theme.css
+++ b/streamlit/lck_theme.css
@@ -1,0 +1,138 @@
+:root {
+    --lck-bg: #070d1f;
+    --lck-bg-soft: #0f1a38;
+    --lck-card: #111b35cc;
+    --lck-border: #3b7be0;
+    --lck-accent: #d9b15f;
+    --lck-text: #e9f0ff;
+    --lck-muted: #a7b8dc;
+}
+
+.stApp {
+    background:
+        radial-gradient(circle at 15% 0%, #1a2f62 0%, rgba(26, 47, 98, 0) 38%),
+        radial-gradient(circle at 85% 100%, #193465 0%, rgba(25, 52, 101, 0) 30%),
+        linear-gradient(145deg, var(--lck-bg) 0%, #040812 100%);
+    color: var(--lck-text);
+}
+
+[data-testid="stHeader"] {
+    background: rgba(4, 10, 24, 0.72);
+}
+
+[data-testid="stSidebar"] {
+    background: linear-gradient(180deg, #101c3d 0%, #0a1229 100%);
+    border-right: 1px solid rgba(59, 123, 224, 0.45);
+}
+
+[data-testid="stSidebarNav"] a {
+    border-radius: 10px;
+}
+
+[data-testid="stSidebarNav"] a:hover {
+    background: rgba(59, 123, 224, 0.22);
+}
+
+[data-testid="stSidebarNav"] a[aria-current="page"] {
+    background: rgba(217, 177, 95, 0.22);
+    border: 1px solid rgba(217, 177, 95, 0.5);
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: #f2f6ff !important;
+    letter-spacing: 0.2px;
+}
+
+p, li, label, [data-testid="stMarkdownContainer"] {
+    color: var(--lck-text);
+}
+
+[data-testid="stForm"] {
+    background: var(--lck-card);
+    border: 1px solid rgba(59, 123, 224, 0.55);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+[data-testid="stMetric"] {
+    background: rgba(17, 27, 53, 0.82);
+    border: 1px solid rgba(59, 123, 224, 0.55);
+    border-radius: 14px;
+    padding: 8px 12px;
+}
+
+button[kind="primary"] {
+    background: linear-gradient(135deg, #1f5ec4 0%, #2f7fff 100%) !important;
+    border: 1px solid rgba(217, 177, 95, 0.65) !important;
+    color: white !important;
+    box-shadow: 0 6px 18px rgba(26, 90, 194, 0.3);
+}
+
+button[kind="primary"]:hover {
+    filter: brightness(1.08);
+}
+
+div[data-baseweb="select"] > div {
+    background: rgba(11, 21, 45, 0.84);
+    border-color: rgba(59, 123, 224, 0.45);
+}
+
+.stTextInput input, .stNumberInput input {
+    background: rgba(11, 21, 45, 0.84);
+}
+
+[data-testid="stDataFrame"] {
+    border: 1px solid rgba(59, 123, 224, 0.35);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.lck-hero {
+    background: linear-gradient(120deg, rgba(35, 78, 156, 0.45) 0%, rgba(19, 34, 72, 0.92) 60%);
+    border: 1px solid rgba(217, 177, 95, 0.55);
+    border-radius: 18px;
+    padding: 24px 28px;
+    margin-bottom: 18px;
+}
+
+.lck-hero-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #f8fbff;
+    margin: 0 0 8px 0;
+}
+
+.lck-hero-subtitle {
+    color: var(--lck-muted);
+    margin: 0;
+    line-height: 1.6;
+}
+
+.lck-chip {
+    display: inline-block;
+    padding: 5px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(217, 177, 95, 0.65);
+    color: var(--lck-accent);
+    font-size: 0.78rem;
+    margin-bottom: 12px;
+}
+
+.lck-card {
+    background: rgba(15, 26, 56, 0.9);
+    border: 1px solid rgba(59, 123, 224, 0.45);
+    border-radius: 14px;
+    padding: 14px 16px;
+}
+
+.lck-card-title {
+    color: var(--lck-accent);
+    margin: 0 0 8px 0;
+    font-size: 0.95rem;
+}
+
+.lck-card-body {
+    color: var(--lck-muted);
+    margin: 0;
+    font-size: 0.88rem;
+}

--- a/streamlit/main.py
+++ b/streamlit/main.py
@@ -1,12 +1,23 @@
 import streamlit as st
 import matplotlib.pyplot as plt
 from matplotlib import font_manager, rc
+from pathlib import Path
 
 font_path = "streamlit/fonts/NanumGothic-Regular.ttf"
 
 font_manager.fontManager.addfont(font_path)
 plt.rcParams["font.family"] = font_manager.FontProperties(fname=font_path).get_name()
 plt.rcParams["axes.unicode_minus"] = False
+
+
+def apply_lck_theme():
+    css_path = Path(__file__).with_name("lck_theme.css")
+    if css_path.exists():
+        theme_css = css_path.read_text(encoding="utf-8")
+        st.markdown(f"<style>{theme_css}</style>", unsafe_allow_html=True)
+
+
+apply_lck_theme()
 
 pg_list = [
     st.Page("pg/home.py", title="홈"),

--- a/streamlit/pg/home.py
+++ b/streamlit/pg/home.py
@@ -2,10 +2,45 @@ import streamlit as st
 
 st.set_page_config(page_title="Home", layout="wide")
 
-md_text = """
-# 3기 데이터톤
-- 팀/선수별 퍼포먼스 지표 확인 및 전략 전력 분석 지원을 위한 EDA
-- 경기 결과 예측을 위한 모델 개발
-"""
+st.markdown(
+    """
+    <div class="lck-hero">
+        <span class="lck-chip">LCK ANALYTICS CENTER</span>
+        <h1 class="lck-hero-title">3기 데이터톤 | LCK 인사이트 대시보드</h1>
+        <p class="lck-hero-subtitle">
+            팀/선수 퍼포먼스 지표와 밴픽 기반 예측을 결합해
+            실전 전략 수립에 필요한 핵심 데이터를 한 화면에서 확인합니다.
+        </p>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
 
-st.markdown(md_text)
+col1, col2, col3 = st.columns(3)
+col1.markdown(
+    """
+    <div class="lck-card">
+        <h3 class="lck-card-title">전력 분석</h3>
+        <p class="lck-card-body">LCK 팀별 지표를 비교해 강점/약점과 메타 적응 흐름을 파악합니다.</p>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+col2.markdown(
+    """
+    <div class="lck-card">
+        <h3 class="lck-card-title">사전 예측</h3>
+        <p class="lck-card-body">리그, 진영, 밴픽 입력으로 경기 전 승률을 빠르게 추정합니다.</p>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+col3.markdown(
+    """
+    <div class="lck-card">
+        <h3 class="lck-card-title">데이터 기반 의사결정</h3>
+        <p class="lck-card-body">코칭 스태프와 팬이 같은 지표를 공유하며 전략 토론에 활용할 수 있습니다.</p>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)

--- a/streamlit/pg/inference.py
+++ b/streamlit/pg/inference.py
@@ -5,63 +5,77 @@ import streamlit as st
 import pandas as pd
 import json
 import pytz
+import joblib
+from catboost import CatBoostClassifier, Pool
 
 st.set_page_config(layout="wide")
 DATA_PATH = "LoLesports_data/"
 ARTIFACTS_PATH = "output/"
 
-teams_train = pd.read_csv(f"{DATA_PATH}teams_train.csv")
-teams_test = pd.read_csv(f"{DATA_PATH}teams_test.csv")
-train_data = pd.concat([teams_train, teams_test], ignore_index=True)
+@st.cache_data(show_spinner=False)
+def load_base_data(data_path):
+    teams_train = pd.read_csv(f"{data_path}teams_train.csv")
+    teams_test = pd.read_csv(f"{data_path}teams_test.csv")
+    train_data = pd.concat([teams_train, teams_test], ignore_index=True)
 
-jh_featured_data = pd.read_csv(f"{DATA_PATH}featured_data.csv")
-if "gameid" in jh_featured_data.columns:
-    jh_featured_data.drop("gameid", axis=1, inplace=True)
+    temp_opp_teams = (
+        train_data.groupby("gameid")["teamname"]
+        .transform(lambda x: x.iloc[::-1].values)
+        .to_frame("opp_teamname")
+    )
+    train_data = pd.concat([train_data, temp_opp_teams], axis=1)
+    train_data.drop("gameid", axis=1, inplace=True)
+    train_data["date"] = pd.to_datetime(train_data["date"])
+    train_data["year"] = train_data["date"].dt.year
+    train_data["month"] = train_data["date"].dt.month
+    train_data["day"] = train_data["date"].dt.day
+    train_data["hour"] = train_data["date"].dt.hour
+    train_data["minute"] = train_data["date"].dt.minute
+    train_data.drop("date", axis=1, inplace=True)
+    return train_data
 
-hj_featured_train = pd.read_csv(f"{DATA_PATH}TEST88_train.csv")
-hj_featured_test = pd.read_csv(f"{DATA_PATH}TEST88_test.csv")
-hj_featured_data = pd.concat([hj_featured_train, hj_featured_test], ignore_index=True)
-if "gameid" in hj_featured_data.columns:
-    hj_featured_data.drop("gameid", axis=1, inplace=True)
-hj_featured_data["side"] = hj_featured_data["side"].map({"Blue": 0, "Red": 1})
 
-with open(f"{ARTIFACTS_PATH}teams.json", "r") as f:
-    teams = json.load(f)
+@st.cache_data(show_spinner=False)
+def load_featured_data(data_path):
+    jh_featured_data = pd.read_csv(f"{data_path}featured_data.csv")
+    if "gameid" in jh_featured_data.columns:
+        jh_featured_data.drop("gameid", axis=1, inplace=True)
 
-with open(f"{ARTIFACTS_PATH}champions.json", "r") as f:
-    champions = json.load(f)
+    hj_featured_train = pd.read_csv(f"{data_path}TEST88_train.csv")
+    hj_featured_test = pd.read_csv(f"{data_path}TEST88_test.csv")
+    hj_featured_data = pd.concat([hj_featured_train, hj_featured_test], ignore_index=True)
+    if "gameid" in hj_featured_data.columns:
+        hj_featured_data.drop("gameid", axis=1, inplace=True)
+    if "side" in hj_featured_data.columns:
+        hj_featured_data["side"] = hj_featured_data["side"].map({"Blue": 0, "Red": 1})
+    return jh_featured_data, hj_featured_data
 
-with open(f"{ARTIFACTS_PATH}leagues.json", "r") as f:
-    leagues = json.load(f)
 
-temp_opp_teams = (
-    train_data.groupby("gameid")["teamname"]
-    .transform(lambda x: x.iloc[::-1].values)
-    .to_frame("opp_teamname")
-)
-train_data = pd.concat([train_data, temp_opp_teams], axis=1)
-train_data.drop("gameid", axis=1, inplace=True)
+@st.cache_data(show_spinner=False)
+def load_metadata(artifacts_path):
+    with open(f"{artifacts_path}teams.json", "r") as f:
+        teams = json.load(f)
+    with open(f"{artifacts_path}champions.json", "r") as f:
+        champions = json.load(f)
+    with open(f"{artifacts_path}leagues.json", "r") as f:
+        leagues = json.load(f)
+    with open(f"{artifacts_path}cat_features.json", "r") as f:
+        cat_cols = json.load(f)
+    return teams, champions, leagues, cat_cols
 
-import joblib
-from catboost import CatBoostClassifier, Pool
 
-jh_stacking = joblib.load(f"{ARTIFACTS_PATH}stacking_0107.pkl")
+@st.cache_resource(show_spinner=False)
+def load_models(artifacts_path):
+    jh_stacking = joblib.load(f"{artifacts_path}stacking_0107.pkl")
+    jh_cat = CatBoostClassifier()
+    jh_cat.load_model(f"{artifacts_path}cat_0107.cbm")
+    hj_stacking = joblib.load(f"{artifacts_path}5_stacking_model_0120.pkl")
+    return jh_stacking, jh_cat, hj_stacking
 
-with open(f"{ARTIFACTS_PATH}cat_features.json", "r") as f:
-    cat_cols = json.load(f)
-
-jh_cat = CatBoostClassifier()
-jh_cat.load_model(f"{ARTIFACTS_PATH}cat_0107.cbm")
-
-hj_stacking = joblib.load(f"{ARTIFACTS_PATH}5_stacking_model_0120.pkl")
-
-train_data["date"] = pd.to_datetime(train_data["date"])
-train_data["year"] = train_data["date"].dt.year
-train_data["month"] = train_data["date"].dt.month
-train_data["day"] = train_data["date"].dt.day
-train_data["hour"] = train_data["date"].dt.hour
-train_data["minute"] = train_data["date"].dt.minute
-train_data.drop("date", axis=1, inplace=True)
+train_data = load_base_data(DATA_PATH)
+jh_featured_data, hj_featured_data = load_featured_data(DATA_PATH)
+teams, champions, leagues, cat_cols = load_metadata(ARTIFACTS_PATH)
+jh_stacking, jh_cat, hj_stacking = load_models(ARTIFACTS_PATH)
 
 
 def update_time(input_data):
@@ -415,6 +429,8 @@ with st.form("예측 폼", border=True):
             for error in validation_errors:
                 st.error(error)
         else:
+            jh_featured_data_for_scale = jh_featured_data.copy()
+            hj_featured_data_for_scale = hj_featured_data.copy()
             input_data_for_jh_model = add_recent10_stats(input_data, train_data)
             input_data_for_jh_model = add_h2h_winrate(
                 input_data_for_jh_model, train_data
@@ -450,32 +466,38 @@ with st.form("예측 폼", border=True):
             cat_featured_data_for_jh_model = preprocess(
                 cat_featured_data_for_jh_model, train_data, champions, teams
             )
-            jh_featured_data = preprocess(
-                jh_featured_data, train_data, champions, teams
+            jh_featured_data_for_scale = preprocess(
+                jh_featured_data_for_scale, train_data, champions, teams
             )
 
             input_data_for_hj_model = preprocess(
                 input_data_for_hj_model, train_data, champions, teams
             )
-            hj_featured_data = preprocess(hj_featured_data, train_data, champions, teams)
+            hj_featured_data_for_scale = preprocess(
+                hj_featured_data_for_scale, train_data, champions, teams
+            )
 
-            input_data_for_jh_model = scale(input_data_for_jh_model, jh_featured_data)
+            input_data_for_jh_model = scale(
+                input_data_for_jh_model, jh_featured_data_for_scale
+            )
             cat_input_data_for_jh_model = scale(
-                cat_input_data_for_jh_model, jh_featured_data
+                cat_input_data_for_jh_model, jh_featured_data_for_scale
             )
             cat_featured_data_for_jh_model = scale(
-                cat_featured_data_for_jh_model, jh_featured_data
+                cat_featured_data_for_jh_model, jh_featured_data_for_scale
             )
             cat_input_data_for_jh_model = Pool(
                 cat_input_data_for_jh_model, cat_features=cat_cols
             )
 
-            input_data_for_hj_model = scale(input_data_for_hj_model, hj_featured_data)
+            input_data_for_hj_model = scale(
+                input_data_for_hj_model, hj_featured_data_for_scale
+            )
 
             pred_jh_stacking = jh_stacking.predict_proba(input_data_for_jh_model)
             pred_jh_cat = jh_cat.predict_proba(cat_input_data_for_jh_model)
 
-            input_data_for_hj_model.columns = hj_featured_data.columns
+            input_data_for_hj_model.columns = hj_featured_data_for_scale.columns
             pred_hj_stacking = hj_stacking.predict_proba(input_data_for_hj_model)
 
             pred = np.mean([pred_jh_stacking, pred_jh_cat, pred_hj_stacking], axis=0)

--- a/streamlit/pg/inference.py
+++ b/streamlit/pg/inference.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from collections import Counter
 import numpy as np
 import streamlit as st
 import pandas as pd
@@ -340,6 +341,14 @@ def scale(input_data, featured_data):
     return input_data
 
 
+def get_prediction_confidence(team_win_rate):
+    if team_win_rate >= 70 or team_win_rate <= 30:
+        return "높음"
+    if team_win_rate >= 60 or team_win_rate <= 40:
+        return "중간"
+    return "낮음"
+
+
 with st.form("예측 폼", border=True):
     teamname = st.selectbox("팀", teams)
     opp_teamname = st.selectbox("상대 팀", teams)
@@ -384,63 +393,106 @@ with st.form("예측 폼", border=True):
     }
 
     if submit_button:
-        input_data_for_jh_model = add_recent10_stats(input_data, train_data)
-        input_data_for_jh_model = add_h2h_winrate(input_data_for_jh_model, train_data)
-        input_data_for_jh_model = add_league_winrate(
-            input_data_for_jh_model, train_data
-        )
-        (
-            input_data_for_jh_model,
-            cat_input_data_for_jh_model,
-            cat_featured_data_for_jh_model,
-        ) = split_data(input_data_for_jh_model, jh_featured_data)
+        validation_errors = []
+        if teamname == opp_teamname:
+            validation_errors.append("팀과 상대 팀은 서로 달라야 합니다.")
 
-        input_data_for_hj_model = update_time(input_data)
-        input_data_for_hj_model = add_recent10_stats(
-            input_data_for_hj_model, train_data
-        )
-        input_data_for_hj_model = add_h2h_winrate(input_data_for_hj_model, train_data)
-        input_data_for_hj_model = add_league_winrate(
-            input_data_for_hj_model, train_data
-        )
-        (
-            input_data_for_hj_model,
-            cat_input_data_for_hj_model,
-            cat_featured_data_for_hj_model,
-        ) = split_data(input_data_for_hj_model, hj_featured_data)
+        draft_champions = [ban1, ban2, ban3, ban4, ban5, pick1, pick2, pick3, pick4, pick5]
+        duplicated_champions = [
+            champion
+            for champion, count in Counter(draft_champions).items()
+            if count > 1
+        ]
+        if duplicated_champions:
+            duplicate_text = ", ".join(duplicated_champions[:5])
+            validation_errors.append(
+                f"밴/픽에 중복 챔피언이 있습니다: {duplicate_text}. 중복 없이 선택해주세요."
+            )
 
-        input_data_for_jh_model = preprocess(
-            input_data_for_jh_model, train_data, champions, teams
-        )
-        cat_featured_data_for_jh_model = preprocess(
-            cat_featured_data_for_jh_model, train_data, champions, teams
-        )
-        jh_featured_data = preprocess(jh_featured_data, train_data, champions, teams)
+        if validation_errors:
+            for error in validation_errors:
+                st.error(error)
+        else:
+            input_data_for_jh_model = add_recent10_stats(input_data, train_data)
+            input_data_for_jh_model = add_h2h_winrate(
+                input_data_for_jh_model, train_data
+            )
+            input_data_for_jh_model = add_league_winrate(
+                input_data_for_jh_model, train_data
+            )
+            (
+                input_data_for_jh_model,
+                cat_input_data_for_jh_model,
+                cat_featured_data_for_jh_model,
+            ) = split_data(input_data_for_jh_model, jh_featured_data)
 
-        input_data_for_hj_model = preprocess(
-            input_data_for_hj_model, train_data, champions, teams
-        )
-        hj_featured_data = preprocess(hj_featured_data, train_data, champions, teams)
+            input_data_for_hj_model = update_time(input_data)
+            input_data_for_hj_model = add_recent10_stats(
+                input_data_for_hj_model, train_data
+            )
+            input_data_for_hj_model = add_h2h_winrate(
+                input_data_for_hj_model, train_data
+            )
+            input_data_for_hj_model = add_league_winrate(
+                input_data_for_hj_model, train_data
+            )
+            (
+                input_data_for_hj_model,
+                cat_input_data_for_hj_model,
+                cat_featured_data_for_hj_model,
+            ) = split_data(input_data_for_hj_model, hj_featured_data)
 
-        input_data_for_jh_model = scale(input_data_for_jh_model, jh_featured_data)
-        cat_input_data_for_jh_model = scale(
-            cat_input_data_for_jh_model, jh_featured_data
-        )
-        cat_featured_data_for_jh_model = scale(
-            cat_featured_data_for_jh_model, jh_featured_data
-        )
-        cat_input_data_for_jh_model = Pool(
-            cat_input_data_for_jh_model, cat_features=cat_cols
-        )
+            input_data_for_jh_model = preprocess(
+                input_data_for_jh_model, train_data, champions, teams
+            )
+            cat_featured_data_for_jh_model = preprocess(
+                cat_featured_data_for_jh_model, train_data, champions, teams
+            )
+            jh_featured_data = preprocess(
+                jh_featured_data, train_data, champions, teams
+            )
 
-        input_data_for_hj_model = scale(input_data_for_hj_model, hj_featured_data)
+            input_data_for_hj_model = preprocess(
+                input_data_for_hj_model, train_data, champions, teams
+            )
+            hj_featured_data = preprocess(hj_featured_data, train_data, champions, teams)
 
-        pred_jh_stacking = jh_stacking.predict_proba(input_data_for_jh_model)
-        pred_jh_cat = jh_cat.predict_proba(cat_input_data_for_jh_model)
+            input_data_for_jh_model = scale(input_data_for_jh_model, jh_featured_data)
+            cat_input_data_for_jh_model = scale(
+                cat_input_data_for_jh_model, jh_featured_data
+            )
+            cat_featured_data_for_jh_model = scale(
+                cat_featured_data_for_jh_model, jh_featured_data
+            )
+            cat_input_data_for_jh_model = Pool(
+                cat_input_data_for_jh_model, cat_features=cat_cols
+            )
 
-        input_data_for_hj_model.columns = hj_featured_data.columns
-        pred_hj_stacking = hj_stacking.predict_proba(input_data_for_hj_model)
+            input_data_for_hj_model = scale(input_data_for_hj_model, hj_featured_data)
 
-        pred = np.mean([pred_jh_stacking, pred_jh_cat, pred_hj_stacking], axis=0)
-        st.write(f"{teamname} 승리 확률: {pred[0][1] * 100:.1f}%")
-        st.write(f"{opp_teamname} 승리 확률: {pred[0][0] * 100:.1f}%")
+            pred_jh_stacking = jh_stacking.predict_proba(input_data_for_jh_model)
+            pred_jh_cat = jh_cat.predict_proba(cat_input_data_for_jh_model)
+
+            input_data_for_hj_model.columns = hj_featured_data.columns
+            pred_hj_stacking = hj_stacking.predict_proba(input_data_for_hj_model)
+
+            pred = np.mean([pred_jh_stacking, pred_jh_cat, pred_hj_stacking], axis=0)
+
+            team_win_rate = pred[0][1] * 100
+            opp_win_rate = pred[0][0] * 100
+
+            st.subheader("예측 결과")
+            st.caption(
+                f"리그: {league} | 패치: {patch} | 진영: {side} | 경기 시간: {date} {time.strftime('%H:%M')}"
+            )
+
+            col1, col2 = st.columns(2)
+            col1.metric(f"{teamname} 승리 확률", f"{team_win_rate:.1f}%")
+            col2.metric(f"{opp_teamname} 승리 확률", f"{opp_win_rate:.1f}%")
+
+            st.info(f"예측 신뢰도: {get_prediction_confidence(team_win_rate)}")
+
+            with st.expander("모델별 확률 보기"):
+                st.write(f"Stacking-A ({teamname}) : {pred_jh_stacking[0][1] * 100:.1f}%")
+                st.write(f"CatBoost ({teamname}) : {pred_jh_cat[0][1] * 100:.1f}%")
+                st.write(f"Stacking-B ({teamname}) : {pred_hj_stacking[0][1] * 100:.1f}%")

--- a/streamlit/pg/inference.py
+++ b/streamlit/pg/inference.py
@@ -366,23 +366,28 @@ def get_prediction_confidence(team_win_rate):
 
 
 with st.form("예측 폼", border=True):
-    teamname = st.selectbox("팀", teams)
-    opp_teamname = st.selectbox("상대 팀", teams)
+    teamname = st.selectbox("팀", teams, index=0)
+    opp_teamname = st.selectbox("상대 팀", teams, index=1 if len(teams) > 1 else 0)
     patch = st.number_input("패치 버전", value=14.23)
     league = st.selectbox("리그", leagues)
     side = st.selectbox("진영", ["Blue", "Red"])
     date = st.date_input("날짜", value=datetime.today())
     time = st.time_input("시간", value=datetime.now().time())
-    ban1 = st.selectbox("밴 1", champions)
-    ban2 = st.selectbox("밴 2", champions)
-    ban3 = st.selectbox("밴 3", champions)
-    ban4 = st.selectbox("밴 4", champions)
-    ban5 = st.selectbox("밴 5", champions)
-    pick1 = st.selectbox("픽 1", champions)
-    pick2 = st.selectbox("픽 2", champions)
-    pick3 = st.selectbox("픽 3", champions)
-    pick4 = st.selectbox("픽 4", champions)
-    pick5 = st.selectbox("픽 5", champions)
+
+    default_champion_idx = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    if len(champions) < 10:
+        default_champion_idx = [i % len(champions) for i in range(10)]
+
+    ban1 = st.selectbox("밴 1", champions, index=default_champion_idx[0])
+    ban2 = st.selectbox("밴 2", champions, index=default_champion_idx[1])
+    ban3 = st.selectbox("밴 3", champions, index=default_champion_idx[2])
+    ban4 = st.selectbox("밴 4", champions, index=default_champion_idx[3])
+    ban5 = st.selectbox("밴 5", champions, index=default_champion_idx[4])
+    pick1 = st.selectbox("픽 1", champions, index=default_champion_idx[5])
+    pick2 = st.selectbox("픽 2", champions, index=default_champion_idx[6])
+    pick3 = st.selectbox("픽 3", champions, index=default_champion_idx[7])
+    pick4 = st.selectbox("픽 4", champions, index=default_champion_idx[8])
+    pick5 = st.selectbox("픽 5", champions, index=default_champion_idx[9])
     submit_button = st.form_submit_button("예측")
 
     input_data = {

--- a/streamlit/pg/inference.py
+++ b/streamlit/pg/inference.py
@@ -15,12 +15,14 @@ teams_test = pd.read_csv(f"{DATA_PATH}teams_test.csv")
 train_data = pd.concat([teams_train, teams_test], ignore_index=True)
 
 jh_featured_data = pd.read_csv(f"{DATA_PATH}featured_data.csv")
-jh_featured_data.drop("gameid", axis=1, inplace=True)
+if "gameid" in jh_featured_data.columns:
+    jh_featured_data.drop("gameid", axis=1, inplace=True)
 
 hj_featured_train = pd.read_csv(f"{DATA_PATH}TEST88_train.csv")
 hj_featured_test = pd.read_csv(f"{DATA_PATH}TEST88_test.csv")
 hj_featured_data = pd.concat([hj_featured_train, hj_featured_test], ignore_index=True)
-hj_featured_data.drop("gameid", axis=1, inplace=True)
+if "gameid" in hj_featured_data.columns:
+    hj_featured_data.drop("gameid", axis=1, inplace=True)
 hj_featured_data["side"] = hj_featured_data["side"].map({"Blue": 0, "Red": 1})
 
 with open(f"{ARTIFACTS_PATH}teams.json", "r") as f:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Added `AGENTS.md` with `## Cursor Cloud specific instructions` for this repository.
- Documented non-obvious runtime caveats for cloud agents:
  - run Streamlit from repo root due relative paths
  - require `git lfs pull` + `git lfs checkout` before app run
  - hello-world verification flow (`경기 전 사전예측` -> `예측`)
  - dashboard page network dependency (`raw.githubusercontent.com`)
  - practical lint/test sanity commands
- Updated `streamlit/pg/inference.py` UX:
  - input validation (same team check, duplicate ban/pick champion check)
  - clearer prediction output (metrics, confidence label, per-model probability details)
  - robust guards for optional/missing source columns
  - valid defaults (different teams + unique champions) for immediate first-submit predictions
- Added performance improvements in `inference.py`:
  - `st.cache_data` for base datasets / featured datasets / metadata JSON loading
  - `st.cache_resource` for model loading
  - removed in-place mutation of shared featured data by using per-submit copies
- Added LCK-inspired visual design:
  - global CSS theme (`streamlit/lck_theme.css`) with dark navy + gold accent palette
  - themed sidebar, forms, metric cards, tables, and primary buttons
  - upgraded home page to hero layout + 3 feature cards (`streamlit/pg/home.py`)

## Validated startup update script
```bash
[ -d .venv ] || python3 -m venv .venv
./.venv/bin/python -m pip install --upgrade pip
./.venv/bin/pip install -r requirements.txt
./.venv/bin/pip install streamlit pandas numpy matplotlib plotly pytz
git lfs pull
git lfs checkout
```

## Validation performed
- Re-ran dependency refresh script and confirmed idempotent installs.
- Restarted Streamlit and verified health endpoint.
- UI tested prediction page validation + successful prediction rendering.
- Re-tested after caching and design commits to confirm no regression.

## Artifacts
[lck_theme_and_prediction_demo.mp4](https://cursor.com/agents/bc-6b43448b-9e8e-4de9-b75b-f835307b0581/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flck_theme_and_prediction_demo.mp4)
[lck-home-hero-banner](https://cursor.com/agents/bc-6b43448b-9e8e-4de9-b75b-f835307b0581/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flck_home_hero_banner.webp)
[lck-home-dark-theme](https://cursor.com/agents/bc-6b43448b-9e8e-4de9-b75b-f835307b0581/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flck_home_dark_theme.webp)
[lck-inference-form-theme](https://cursor.com/agents/bc-6b43448b-9e8e-4de9-b75b-f835307b0581/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flck_inference_form_theme.webp)
[lck-inference-result-cards](https://cursor.com/agents/bc-6b43448b-9e8e-4de9-b75b-f835307b0581/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flck_inference_result_cards.webp)
[lck-inference-model-details](https://cursor.com/agents/bc-6b43448b-9e8e-4de9-b75b-f835307b0581/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flck_inference_model_details.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b43448b-9e8e-4de9-b75b-f835307b0581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b43448b-9e8e-4de9-b75b-f835307b0581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

